### PR TITLE
xcode26に上げて出たエラーの修正

### DIFF
--- a/flash_cards/flash_cards.xcodeproj/project.pbxproj
+++ b/flash_cards/flash_cards.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/flash_cards/flash_cards.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/flash_cards/flash_cards.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "e28911721538fa0c2439e92320bad13e3200866f",
-        "version" : "2.2.3"
+        "revision" : "bf498690e1f6b4af790260f542e8428a4ba10d78",
+        "version" : "2.6.0"
       }
     },
     {


### PR DESCRIPTION
swift-navigationでエラーが出ていたのでアップデート

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to support newer tooling versions.
  * Updated navigation framework dependency to the latest stable release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->